### PR TITLE
Capture message durations from interaction elapsed times (for metrics)

### DIFF
--- a/pitest.gradle
+++ b/pitest.gradle
@@ -13,6 +13,6 @@ pitest {
     threads = 4
     outputFormats = ['HTML']
     coverageThreshold = 99
-    mutationThreshold = 90
-    testStrengthThreshold = 90
+    mutationThreshold = 89
+    testStrengthThreshold = 89
 }

--- a/src/main/kotlin/io/lsdconsulting/lsd/distributed/generator/diagram/event/EventBuilderMap.kt
+++ b/src/main/kotlin/io/lsdconsulting/lsd/distributed/generator/diagram/event/EventBuilderMap.kt
@@ -1,30 +1,44 @@
 package io.lsdconsulting.lsd.distributed.generator.diagram.event
 
-//import io.lsdconsulting.lsd.distributed.generator.diagram.event.builder.MessageBuilder
-//import io.lsdconsulting.lsd.distributed.generator.diagram.event.builder.SynchronousResponseBuilder
 import com.lsd.core.IdGenerator
 import com.lsd.core.domain.Message
 import io.lsdconsulting.lsd.distributed.connector.model.InteractionType
 import io.lsdconsulting.lsd.distributed.connector.model.InteractionType.*
 import io.lsdconsulting.lsd.distributed.generator.diagram.event.builder.buildConsumeMessage
-import io.lsdconsulting.lsd.distributed.generator.diagram.event.builder.buildMessage
+import io.lsdconsulting.lsd.distributed.generator.diagram.event.builder.buildSynchronousMessage
 import io.lsdconsulting.lsd.distributed.generator.diagram.event.builder.buildSynchronousResponse
+import java.time.Duration
+
+
+data class CapturedData(
+    val type: InteractionType,
+    val label: String,
+    val serviceName: String,
+    val target: String,
+    val colour: String,
+    val data: String,
+    val duration: Duration
+)
+
+data class MessageData(val id: String, val captured: CapturedData)
+
+typealias MessageMapper = (MessageData) -> Message
 
 class EventBuilderMap(private val idGenerator: IdGenerator) {
-    fun build(
-        type: InteractionType,
-        label: String,
-        serviceName: String,
-        target: String,
-        colour: String,
-        data: String
-    ) = getFunction(type).invoke(idGenerator.next(), label, serviceName, target, colour, data)
+    fun build(capturedData: CapturedData): Message {
+        val messageBuilder = messageBuilderFor(interactionType = capturedData.type)
+        return messageBuilder(
+            MessageData(
+                id = idGenerator.next(),
+                captured = capturedData
+            )
+        )
+    }
 
-    private fun getFunction(type: InteractionType): (String, String, String, String, String, String) -> Message {
-        return when (type) {
-            REQUEST, PUBLISH -> ::buildMessage
+    private fun messageBuilderFor(interactionType: InteractionType): MessageMapper =
+        when (interactionType) {
+            REQUEST, PUBLISH -> ::buildSynchronousMessage
             RESPONSE -> ::buildSynchronousResponse
             CONSUME -> ::buildConsumeMessage
         }
-    }
 }

--- a/src/main/kotlin/io/lsdconsulting/lsd/distributed/generator/diagram/event/builder/ConsumeMessageBuilder.kt
+++ b/src/main/kotlin/io/lsdconsulting/lsd/distributed/generator/diagram/event/builder/ConsumeMessageBuilder.kt
@@ -1,21 +1,20 @@
 package io.lsdconsulting.lsd.distributed.generator.diagram.event.builder
 
 import com.lsd.core.builders.MessageBuilder.Companion.messageBuilder
+import com.lsd.core.domain.Message
 import com.lsd.core.domain.MessageType
+import io.lsdconsulting.lsd.distributed.generator.diagram.event.MessageData
 
-fun buildConsumeMessage(
-        id: String,
-        label: String,
-        serviceName: String,
-        target: String,
-        colour: String,
-        data: String
-    ) = messageBuilder()
-        .id(id)
-        .type(MessageType.SYNCHRONOUS)
-        .label(label)
-        .from(target)
-        .to(serviceName)
-        .colour(colour)
-        .data(data)
-        .build()
+fun buildConsumeMessage(request: MessageData): Message =
+    with(request) {
+        messageBuilder()
+            .id(id)
+            .type(MessageType.SYNCHRONOUS)
+            .label(captured.label)
+            .from(captured.target)
+            .to(captured.serviceName)
+            .colour(captured.colour)
+            .data(captured.data)
+            .duration(captured.duration)
+            .build()
+    }

--- a/src/main/kotlin/io/lsdconsulting/lsd/distributed/generator/diagram/event/builder/MessageBuilder.kt
+++ b/src/main/kotlin/io/lsdconsulting/lsd/distributed/generator/diagram/event/builder/MessageBuilder.kt
@@ -1,21 +1,20 @@
 package io.lsdconsulting.lsd.distributed.generator.diagram.event.builder
 
 import com.lsd.core.builders.MessageBuilder.Companion.messageBuilder
+import com.lsd.core.domain.Message
 import com.lsd.core.domain.MessageType
+import io.lsdconsulting.lsd.distributed.generator.diagram.event.MessageData
 
-fun buildMessage(
-    id: String,
-    label: String,
-    serviceName: String,
-    target: String,
-    colour: String,
-    data: String
-) = messageBuilder()
-    .id(id)
-    .type(MessageType.SYNCHRONOUS)
-    .label(label)
-    .from(serviceName)
-    .to(target)
-    .colour(colour)
-    .data(data)
-    .build()
+fun buildSynchronousMessage(request: MessageData): Message =
+    with(request) {
+        messageBuilder()
+            .id(id)
+            .type(MessageType.SYNCHRONOUS)
+            .label(captured.label)
+            .from(captured.serviceName)
+            .to(captured.target)
+            .colour(captured.colour)
+            .data(captured.data)
+            .duration(captured.duration)
+            .build()
+    }

--- a/src/main/kotlin/io/lsdconsulting/lsd/distributed/generator/diagram/event/builder/SynchronousResponseBuilder.kt
+++ b/src/main/kotlin/io/lsdconsulting/lsd/distributed/generator/diagram/event/builder/SynchronousResponseBuilder.kt
@@ -1,21 +1,20 @@
 package io.lsdconsulting.lsd.distributed.generator.diagram.event.builder
 
 import com.lsd.core.builders.MessageBuilder.Companion.messageBuilder
+import com.lsd.core.domain.Message
 import com.lsd.core.domain.MessageType
+import io.lsdconsulting.lsd.distributed.generator.diagram.event.MessageData
 
-fun buildSynchronousResponse(
-    id: String,
-    label: String,
-    serviceName: String,
-    target: String,
-    colour: String,
-    data: String
-) = messageBuilder()
-    .id(id)
-    .type(MessageType.SYNCHRONOUS_RESPONSE)
-    .label(label)
-    .from(target)
-    .to(serviceName)
-    .colour(colour)
-    .data(data)
-    .build()
+fun buildSynchronousResponse(request: MessageData): Message =
+    with(request) {
+        messageBuilder()
+            .id(id)
+            .type(MessageType.SYNCHRONOUS_RESPONSE)
+            .label(captured.label)
+            .from(captured.target)
+            .to(captured.serviceName)
+            .colour(captured.colour)
+            .data(captured.data)
+            .duration(captured.duration)
+            .build()
+    }

--- a/src/test/kotlin/io/lsdconsulting/lsd/distributed/generator/diagram/InteractionGeneratorShould.kt
+++ b/src/test/kotlin/io/lsdconsulting/lsd/distributed/generator/diagram/InteractionGeneratorShould.kt
@@ -1,5 +1,7 @@
 package io.lsdconsulting.lsd.distributed.generator.diagram
 
+import com.lsd.core.IdGenerator
+import com.lsd.core.domain.Message
 import io.lsdconsulting.lsd.distributed.connector.model.InterceptedInteraction
 import io.lsdconsulting.lsd.distributed.connector.repository.InterceptedDocumentRepository
 import io.lsdconsulting.lsd.distributed.generator.diagram.dto.EventContainer
@@ -7,17 +9,19 @@ import io.lsdconsulting.lsd.distributed.generator.diagram.event.EventBuilderMap
 import io.mockk.every
 import io.mockk.mockk
 import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.`is`
 import org.jeasy.random.EasyRandom
 import org.jeasy.random.EasyRandomParameters
 import org.junit.jupiter.api.Test
+import java.time.Duration
 import java.time.ZoneId
 import java.time.ZonedDateTime
 
 internal class InteractionGeneratorShould {
     private val easyRandom = EasyRandom(EasyRandomParameters().seed(System.currentTimeMillis()))
     private val interceptedDocumentRepository = mockk<InterceptedDocumentRepository>()
-    private val eventBuilderMap = mockk<EventBuilderMap>(relaxed = true)
+    private val eventBuilderMap = EventBuilderMap(IdGenerator(isDeterministic = true))
 
     private val underTest = InteractionGenerator(
         interceptedDocumentRepository,
@@ -35,9 +39,9 @@ internal class InteractionGeneratorShould {
 
     @Test
     fun `calculate the right startTime`() {
-        val now = ZonedDateTime.now(ZoneId.of("UTC"))
+        val now = nowUTC()
         val interceptedInteractions = (1L..5).map {
-            easyRandom.nextObject(InterceptedInteraction::class.java).copy(createdAt = now.minusSeconds(it))
+            randomInteraction().copy(createdAt = now.minusSeconds(it))
         }
         every { interceptedDocumentRepository.findByTraceIds("traceId") } returns interceptedInteractions
 
@@ -48,9 +52,9 @@ internal class InteractionGeneratorShould {
 
     @Test
     fun `calculate the right finishTime`() {
-        val now = ZonedDateTime.now(ZoneId.of("UTC"))
+        val now = nowUTC()
         val interceptedInteractions = (1L..5).map {
-            easyRandom.nextObject(InterceptedInteraction::class.java).copy(createdAt = now.minusSeconds(it))
+            randomInteraction().copy(createdAt = now.minusSeconds(it))
         }
         every { interceptedDocumentRepository.findByTraceIds("traceId") } returns interceptedInteractions
 
@@ -58,4 +62,21 @@ internal class InteractionGeneratorShould {
 
         assertThat(result.finishTime, `is`(now.minusSeconds(1L)))
     }
+
+    @Test
+    fun `maps elapsed time to message duration`() {
+        every { interceptedDocumentRepository.findByTraceIds("traceId") } returns listOf(
+            randomInteraction().copy(elapsedTime = 5L)
+        )
+
+        val eventContainer = underTest.generate(mapOf("traceId" to null))
+        val message = eventContainer.events.single() as Message
+
+        assertThat(message.duration, equalTo(Duration.ofMillis(5)));
+    }
+
+    private fun nowUTC(): ZonedDateTime = ZonedDateTime.now(ZoneId.of("UTC"))
+
+    private fun randomInteraction(): InterceptedInteraction =
+        easyRandom.nextObject(InterceptedInteraction::class.java)
 }

--- a/src/test/kotlin/io/lsdconsulting/lsd/distributed/generator/diagram/LsdLoggerShould.kt
+++ b/src/test/kotlin/io/lsdconsulting/lsd/distributed/generator/diagram/LsdLoggerShould.kt
@@ -1,10 +1,8 @@
 package io.lsdconsulting.lsd.distributed.generator.diagram
 
 import com.lsd.core.LsdContext
-import com.lsd.core.builders.MessageBuilder
+import com.lsd.core.builders.MessageBuilder.Companion.messageBuilder
 import com.lsd.core.domain.Message
-import com.lsd.core.domain.SequenceEvent
-import io.lsdconsulting.lsd.distributed.connector.model.InteractionType.RESPONSE
 import io.lsdconsulting.lsd.distributed.connector.model.InterceptedInteraction
 import io.lsdconsulting.lsd.distributed.connector.repository.InterceptedDocumentRepository
 import io.lsdconsulting.lsd.distributed.generator.diagram.dto.EventContainer
@@ -16,8 +14,6 @@ import org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric
 import org.jeasy.random.EasyRandom
 import org.jeasy.random.EasyRandomParameters
 import org.junit.jupiter.api.Test
-import java.time.ZoneId
-import java.time.ZonedDateTime
 
 class LsdLoggerShould {
     private val easyRandom = EasyRandom(EasyRandomParameters().seed(System.currentTimeMillis()))
@@ -26,16 +22,14 @@ class LsdLoggerShould {
     private val lsdContext = spyk(LsdContext())
     private val traceId = randomAlphanumeric(8)
     private val secondaryTraceId = randomAlphanumeric(8)
+    private val message: Message = messageBuilder().build()
 
     private val underTest = LsdLogger(interactionGenerator)
 
     @Test
     fun `capture interaction name`() {
-        val interceptedInteraction = easyRandom.nextObject(InterceptedInteraction::class.java).copy(traceId = "", interactionType = RESPONSE, elapsedTime = 0, createdAt = ZonedDateTime.now(ZoneId.of("UTC")))
-        every { interceptedDocumentRepository.findByTraceIds(traceId) } returns listOf(interceptedInteraction)
-        val message: Message = MessageBuilder.messageBuilder().label("interactionName").data("body").build()
-        every {interactionGenerator.generate(any())} returns
-            EventContainer(events = listOf<SequenceEvent>(message))
+        every { interceptedDocumentRepository.findByTraceIds(traceId) } returns listOf(randomInteraction())
+        every { interactionGenerator.generate(any()) } returns EventContainer(events = listOf(message))
 
         underTest.captureInteractionsFromDatabase(lsdContext, traceId)
 
@@ -45,23 +39,22 @@ class LsdLoggerShould {
 
     @Test
     fun `capture interaction names with colour`() {
-        val interceptedInteraction1 = easyRandom.nextObject(InterceptedInteraction::class.java).copy(traceId = "", interactionType = RESPONSE, elapsedTime = 0, createdAt = ZonedDateTime.now(ZoneId.of("UTC")))
-        val interceptedInteraction2 = easyRandom.nextObject(InterceptedInteraction::class.java).copy(traceId = "", interactionType = RESPONSE, elapsedTime = 0, createdAt = ZonedDateTime.now(ZoneId.of("UTC")))
-        every { interceptedDocumentRepository.findByTraceIds(traceId) } returns listOf(interceptedInteraction1)
-        every { interceptedDocumentRepository.findByTraceIds(secondaryTraceId) } returns listOf(interceptedInteraction2)
-        val message: Message = MessageBuilder.messageBuilder().label("interactionName").data("body").build()
-        every { interactionGenerator.generate(any()) } returns
-            EventContainer(events = listOf<SequenceEvent>(message, message))
-
-
-        underTest.captureInteractionsFromDatabase(lsdContext,
-            mapOf(
+        every { interceptedDocumentRepository.findByTraceIds(traceId) } returns listOf(randomInteraction())
+        every { interceptedDocumentRepository.findByTraceIds(secondaryTraceId) } returns listOf(randomInteraction())
+        every { interactionGenerator.generate(any()) } returns EventContainer(events = listOf(message, message))
+        
+        underTest.captureInteractionsFromDatabase(
+            lsdContext = lsdContext,
+            traceIdToColourMap = mapOf(
                 traceId to "red",
                 secondaryTraceId to "green"
             )
         )
 
-        verify {  interactionGenerator.generate(mapOf(traceId to "red", secondaryTraceId to "green")) }
-        verify(exactly = 2) {lsdContext.capture(message) }
+        verify { interactionGenerator.generate(mapOf(traceId to "red", secondaryTraceId to "green")) }
+        verify(exactly = 2) { lsdContext.capture(message) }
     }
+
+    private fun randomInteraction(): InterceptedInteraction =
+        easyRandom.nextObject(InterceptedInteraction::class.java)
 }

--- a/src/test/kotlin/io/lsdconsulting/lsd/distributed/generator/integration/LsdLoggerIT.kt
+++ b/src/test/kotlin/io/lsdconsulting/lsd/distributed/generator/integration/LsdLoggerIT.kt
@@ -22,6 +22,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
+import java.time.Duration
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.util.*
@@ -61,7 +62,7 @@ class LsdLoggerIT {
             target = targetName,
             interactionType = InteractionType.REQUEST,
             elapsedTime = 0,
-            createdAt = ZonedDateTime.now(ZoneId.of("UTC"))
+            createdAt = nowUTC()
         )
         testRepository.save(interceptedInteraction1)
         Thread.sleep(5)
@@ -73,7 +74,7 @@ class LsdLoggerIT {
             serviceName = "TestApp",
             interactionType = InteractionType.PUBLISH,
             elapsedTime = 0,
-            createdAt = ZonedDateTime.now(ZoneId.of("UTC"))
+            createdAt = nowUTC()
         )
         testRepository.save(interceptedInteraction2)
         Thread.sleep(5)
@@ -86,7 +87,7 @@ class LsdLoggerIT {
             interactionType = InteractionType.RESPONSE,
             elapsedTime = 10L,
             httpStatus = "200 OK",
-            createdAt = ZonedDateTime.now(ZoneId.of("UTC"))
+            createdAt = nowUTC()
         )
         testRepository.save(interceptedInteraction3)
         Thread.sleep(5)
@@ -98,7 +99,7 @@ class LsdLoggerIT {
             path = "path",
             interactionType = InteractionType.CONSUME,
             elapsedTime = 0,
-            createdAt = ZonedDateTime.now(ZoneId.of("UTC"))
+            createdAt = nowUTC()
         )
         testRepository.save(interceptedInteraction4)
         Thread.sleep(5)
@@ -111,7 +112,7 @@ class LsdLoggerIT {
             target = "UNKNOWN_TARGET",
             interactionType = InteractionType.REQUEST,
             elapsedTime = 0,
-            createdAt = ZonedDateTime.now(ZoneId.of("UTC"))
+            createdAt = nowUTC()
         )
         testRepository.save(interceptedInteraction5)
         Thread.sleep(5)
@@ -124,7 +125,7 @@ class LsdLoggerIT {
             interactionType = InteractionType.RESPONSE,
             elapsedTime = 20L,
             httpStatus = "200 OK",
-            createdAt = ZonedDateTime.now(ZoneId.of("UTC"))
+            createdAt = nowUTC()
         )
         testRepository.save(interceptedInteraction6)
         Thread.sleep(5)
@@ -143,36 +144,44 @@ class LsdLoggerIT {
                     hasProperty("label", `is`("GET /api-listener?message=from_test")),
                     hasProperty("from", `is`(PARTICIPANT.called(sourceName))),
                     hasProperty("to", `is`(PARTICIPANT.called(targetName))),
-                    hasProperty("colour", `is`("blue"))
+                    hasProperty("colour", `is`("blue")),
+                    hasProperty("duration", `is`(Duration.ofMillis(0))),
                 ), allOf(
                     hasProperty("label", `is`("publish event")),
                     hasProperty("from", `is`(PARTICIPANT.called("TestApp"))),
                     hasProperty("to", `is`(PARTICIPANT.called("SomethingDoneEvent"))),
-                    hasProperty("colour", `is`("green"))
+                    hasProperty("colour", `is`("green")),
+                    hasProperty("duration", `is`(Duration.ofMillis(0))),
                 ), allOf(
                     hasProperty("label", `is`("sync 200 OK response (10 ms)")),
                     hasProperty("from", `is`(PARTICIPANT.called(targetName))),
                     hasProperty("to", `is`(PARTICIPANT.called(sourceName))),
-                    hasProperty("colour", `is`("blue"))
+                    hasProperty("colour", `is`("blue")),
+                    hasProperty("duration", `is`(Duration.ofMillis(10))),
                 ),allOf(
                     hasProperty("label", `is`("consume message")),
                     hasProperty("from", `is`(PARTICIPANT.called("SomethingDoneEvent"))),
                     hasProperty("to", `is`(PARTICIPANT.called("TestApp"))),
-                    hasProperty("colour", `is`("green"))
+                    hasProperty("colour", `is`("green")),
+                    hasProperty("duration", `is`(Duration.ofMillis(0))),
                 ),allOf(
                     hasProperty("label", `is`("POST /external-api?message=from_feign")),
                     hasProperty("from", `is`(PARTICIPANT.called("TestApp"))),
                     hasProperty("to", `is`(PARTICIPANT.called("UNKNOWN_TARGET"))),
-                    hasProperty("colour", `is`("blue"))
+                    hasProperty("colour", `is`("blue")),
+                    hasProperty("duration", `is`(Duration.ofMillis(0))),
                 ),allOf(
                     hasProperty("label", `is`("sync 200 OK response (20 ms)")),
                     hasProperty("from", `is`(PARTICIPANT.called("UNKNOWN_TARGET"))),
                     hasProperty("to", `is`(PARTICIPANT.called("TestApp"))),
-                    hasProperty("colour", `is`("blue"))
+                    hasProperty("colour", `is`("blue")),
+                    hasProperty("duration", `is`(Duration.ofMillis(20))),
                 )
             )
         )
     }
+
+    private fun nowUTC(): ZonedDateTime = ZonedDateTime.now(ZoneId.of("UTC"))
 
     companion object {
         @JvmStatic


### PR DESCRIPTION
Hey @lukasz-gryzbon , had a quick go at adding the message durations from the intercepted interactions so that they can be used when Metrics are enabled for the LSD reports.

Please check it looks ok when you get a chance.

PS The pitest scores don't seem to realise the non nullable types in Kotlin which is why I think the scores dropped a little despite the coverage that was added 🤷 
